### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: jessicabrentnall Deploy to CO.UK
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/wordshaker/jessicabrentnall/security/code-scanning/5](https://github.com/wordshaker/jessicabrentnall/security/code-scanning/5)

To fix the problem, you should add a `permissions` block to the workflow to explicitly limit the permissions granted to the GITHUB_TOKEN. The best way to do this is to add the `permissions` key at the root level of the workflow file (above `jobs:`), which will apply to all jobs in the workflow unless overridden. For this workflow, the minimal required permission is likely `contents: read`, as the workflow does not interact with issues, pull requests, or require write access to repository contents. You should add the following block after the workflow `name` and before the `on:` key:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
