### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
 
+permissions:
+  contents: read
+
 on: [pull_request]
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/wordshaker/jessicabrentnall/security/code-scanning/3](https://github.com/wordshaker/jessicabrentnall/security/code-scanning/3)

To fix the problem, you should add a `permissions` block to the workflow to restrict the permissions of the GITHUB_TOKEN. The best way is to add the block at the workflow root (top-level, alongside `name` and `on`), so it applies to all jobs unless overridden. For this workflow, the minimal required permission is `contents: read`, which allows the workflow to check out code but not modify repository contents. No additional permissions are needed for the build steps shown. The change should be made at the top of `.github/workflows/build.yml`, after the `name` and before or after the `on` key.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
